### PR TITLE
Add validate object in setItem()

### DIFF
--- a/src/Builders/PaymayaCheckoutBuilder.php
+++ b/src/Builders/PaymayaCheckoutBuilder.php
@@ -141,7 +141,7 @@ class PaymayaCheckoutBuilder
     public function setItem(PaymayaItem $paymayaItem, $quantity = 1): PaymayaCheckoutBuilder
     {
         if (!$paymayaItem instanceof Model) {
-            throw new \ErrorException(get_class($paymayaItem).' must subclass of '.Model::class);
+            throw new \ErrorException(get_class($paymayaItem).' must be a subclass of '.Model::class);
         }
         
         $itemAlreadySet = false;

--- a/src/Builders/PaymayaCheckoutBuilder.php
+++ b/src/Builders/PaymayaCheckoutBuilder.php
@@ -12,6 +12,7 @@ use CoreProc\PayMaya\Requests\Checkout\TotalAmount;
 use CoreProc\PayMaya\Requests\Contact;
 use CoreProc\PayMaya\Requests\RedirectUrl;
 use Coreproc\PaymayaLaravel\Contracts\PaymayaItem;
+use Illuminate\Database\Eloquent\Model;
 
 class PaymayaCheckoutBuilder
 {
@@ -139,6 +140,10 @@ class PaymayaCheckoutBuilder
      */
     public function setItem(PaymayaItem $paymayaItem, $quantity = 1): PaymayaCheckoutBuilder
     {
+        if (!$paymayaItem instanceof Model) {
+            throw new \ErrorException(get_class($paymayaItem).' must subclass of '.Model::class);
+        }
+        
         $itemAlreadySet = false;
 
         if (! empty($this->items)) {


### PR DESCRIPTION

Fixes # .

I've notice this `if ($item['model']->is($paymayaItem))`, so meaning it referring to a model class by laravel, so checking this will prevent reconfigured object

**What changed?**

add check object

**How can it be tested?**



**What are possible test scenarios?**

I intended to create a custom object for if, but i dig this package and notice using `->is()`, meaning its actual laravel model needed, but notice seems to validate it in vendor level

**Add notable screenshots here for easier review**


